### PR TITLE
Fixed qwik version in the starter library package.json from 0.0.0 to ^1.7.3

### DIFF
--- a/starters/apps/library/package.json
+++ b/starters/apps/library/package.json
@@ -33,7 +33,7 @@
     "release": "np"
   },
   "devDependencies": {
-    "@builder.io/qwik": "0.0.0-read-qwik-package-json",
+    "@builder.io/qwik": "^1.7.3",
     "@types/eslint": "^8.56.10",
     "@types/node": "^20.12.7",
     "@typescript-eslint/eslint-plugin": "^7.7.1",


### PR DESCRIPTION
Fixed qwik version in the starter library package.json from 0.0.0 to ^1.7.3; before it cannot install dependencies on new library projects result in a critical broken project